### PR TITLE
Update LogonID

### DIFF
--- a/EMIEWebPortal.Controllers/Controllers/LoginController.cs
+++ b/EMIEWebPortal.Controllers/Controllers/LoginController.cs
@@ -60,9 +60,7 @@ namespace EMIEWebPortal.Controllers
                 if (!String.IsNullOrEmpty(userLogOnID))
                 {
 
-                    var Index = userLogOnID.Split('\\');
-                    //Get only v-id
-                    userLogOnID = Index[1];
+
 
                     //Get complete user object for logged in user
 

--- a/EMIEWebPortal.Controllers/Controllers/UserController.cs
+++ b/EMIEWebPortal.Controllers/Controllers/UserController.cs
@@ -645,7 +645,6 @@ namespace EMIEWebPortal.Controllers
         /// <returns>result of insert operation</returns>
         private int CreateNewUser(UserMapping user)
         {
-            var logonId = user.User.Email.Split('@');
 
             User newUser = new User();
             newUser.UserName = user.User.UserName;
@@ -655,7 +654,7 @@ namespace EMIEWebPortal.Controllers
             newUser.ModifiedById = user.User.CreatedById;
             newUser.ModifiedDate = DateTime.Now;
             newUser.IsActive = user.IsActive;
-            newUser.LoginId = logonId[0].ToString();
+            newUser.LoginId = User.Identity.Name;
 
             DbEntity.Users.Add(newUser);
 


### PR DESCRIPTION
CreateNewUser uses the first part of the email address for LoginId. The LoginController would use the last part of User.Identify.Name to log in.

This only works if the users samAccountName is the same as the users email address- which isn't always true.

I believe this caused Issue 14. 