### PR TITLE
Changed docs.microsoft.com to learn.microsoft.com

### DIFF
--- a/EMIEWebPortal/App/Views/LoginHome.html
+++ b/EMIEWebPortal/App/Views/LoginHome.html
@@ -8,7 +8,7 @@
     <div class="message">
         <p>Welcome to the Enterprise Mode Site List Portal. This portal is intended to help you manage your Enterprise Mode Site List requests.</p>
         <p>Enterprise Mode, a compatibility mode that runs on Internet Explorer 11, lets websites render using a modified browser configuration that’s designed to emulate older versions of Internet Explorer, avoiding the common compatibility problems associated with legacy web apps. Any website that is not compatible with Microsoft Edge can be redirected to Internet Explorer using the best browser configuration via the Enterprise Mode Site List.</p>
-        <p>For more info about Enterprise Mode and site lists, see the <a class="btn-link" href="https://technet.microsoft.com/en-us/itpro/internet-explorer/ie11-deploy-guide/enterprise-mode-overview-for-ie11" target="_blank">Enterprise Mode TechNet articles</a>.</p>
+        <p>For more info about Enterprise Mode and site lists, see the <a class="btn-link" href="https://technet.microsoft.com/itpro/internet-explorer/ie11-deploy-guide/enterprise-mode-overview-for-ie11" target="_blank">Enterprise Mode TechNet articles</a>.</p>
     </div>
     <div class="login">
         <h1>Sign in</h1>

--- a/EMIEWebPortal/App/Views/NewCR.html
+++ b/EMIEWebPortal/App/Views/NewCR.html
@@ -244,7 +244,7 @@
                     </div>
                 </div>
                 <div class="form-row">
-                    <div><span class="EMIEControllabel" title="Tell us if application pages uses X-UA compatible header to restrict a webpage to legacy document modes.">Is an <a href="https://msdn.microsoft.com/en-us/library/jj676915(v=vs.85).aspx" target="_blank">X-UA tag</a> used?  (optional)</span></div>
+                    <div><span class="EMIEControllabel" title="Tell us if application pages uses X-UA compatible header to restrict a webpage to legacy document modes.">Is an <a href="https://msdn.microsoft.com/library/jj676915(v=vs.85).aspx" target="_blank">X-UA tag</a> used?  (optional)</span></div>
                     <div>
                         <select class="form-control" data-ng-model="IsVisible" data-ng-change="ChangeRequired()" data-ng-disabled="DisableXUATag">
                             <option value="">-- Select --</option>

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project contains source code for the Enterprise Mode Site List Portal, a to
 ![Enterprise Mode Site List Portal - Create new request page](https://cloud.githubusercontent.com/assets/7266075/22607091/3cc4e554-ea0b-11e6-90fa-50d0af5e6509.png)
 
 ## Get started
-1. [Prepare](https://docs.microsoft.com/en-us/internet-explorer/ie11-deploy-guide/use-the-enterprise-mode-portal) by reviewing the system requirements, the available role assignments, and the employee workflows.
-2. [Set up](https://docs.microsoft.com/en-us/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal) by following the steps to set up and configure your environment.
-3. [Use](https://docs.microsoft.com/en-us/internet-explorer/ie11-deploy-guide/workflow-processes-enterprise-mode-portal) by following the steps to learn how to use and manage the Enterprise Mode Portal.
+1. [Prepare](https://learn.microsoft.com/internet-explorer/ie11-deploy-guide/use-the-enterprise-mode-portal) by reviewing the system requirements, the available role assignments, and the employee workflows.
+2. [Set up](https://learn.microsoft.com/internet-explorer/ie11-deploy-guide/set-up-enterprise-mode-portal) by following the steps to set up and configure your environment.
+3. [Use](https://learn.microsoft.com/internet-explorer/ie11-deploy-guide/workflow-processes-enterprise-mode-portal) by following the steps to learn how to use and manage the Enterprise Mode Portal.
 
 ## Code of Conduct
 

--- a/packages/EntityFramework.6.1.3/lib/net40/EntityFramework.xml
+++ b/packages/EntityFramework.6.1.3/lib/net40/EntityFramework.xml
@@ -9633,7 +9633,7 @@
             </summary>
             <remarks>
             The public services currently resolved using IDbDependencyResolver are documented here:
-            http://msdn.microsoft.com/en-us/data/jj680697
+            http://msdn.microsoft.com/data/jj680697
             </remarks>
         </member>
         <member name="M:System.Data.Entity.Infrastructure.DependencyResolution.IDbDependencyResolver.GetService(System.Type,System.Object)">

--- a/packages/EntityFramework.6.1.3/lib/net45/EntityFramework.xml
+++ b/packages/EntityFramework.6.1.3/lib/net45/EntityFramework.xml
@@ -9633,7 +9633,7 @@
             </summary>
             <remarks>
             The public services currently resolved using IDbDependencyResolver are documented here:
-            http://msdn.microsoft.com/en-us/data/jj680697
+            http://msdn.microsoft.com/data/jj680697
             </remarks>
         </member>
         <member name="M:System.Data.Entity.Infrastructure.DependencyResolution.IDbDependencyResolver.GetService(System.Type,System.Object)">

--- a/packages/Modernizr.2.6.2/Content/Scripts/modernizr-2.6.2.js
+++ b/packages/Modernizr.2.6.2/Content/Scripts/modernizr-2.6.2.js
@@ -139,7 +139,7 @@ window.Modernizr = (function( window, document, undefined ) {
       // <style> elements in IE6-9 are considered 'NoScope' elements and therefore will be removed
       // when injected with innerHTML. To get around this you need to prepend the 'NoScope' element
       // with a 'scoped' element, in our case the soft-hyphen entity as it won't mess with our measurements.
-      // msdn.microsoft.com/en-us/library/ms533897%28VS.85%29.aspx
+      // msdn.microsoft.com/library/ms533897%28VS.85%29.aspx
       // Documents served as xml will throw if using &shy; so use xml friendly encoded version. See issue #277
       style = ['&#173;','<style id="s', mod, '">', rule, '</style>'].join('');
       div.id = mod;
@@ -543,7 +543,7 @@ window.Modernizr = (function( window, document, undefined ) {
     // FF3.6 was EOL'ed on 4/24/12, but the ESR version of FF10
     // will be supported until FF19 (2/12/13), at which time, ESR becomes FF17.
     // FF10 still uses prefixes, so check for it until then.
-    // for more ESR info, see: mozilla.org/en-US/firefox/organizations/faq/
+    // for more ESR info, see: mozilla.org/firefox/organizations/faq/
     tests['websockets'] = function() {
         return 'WebSocket' in window || 'MozWebSocket' in window;
     };

--- a/packages/Newtonsoft.Json.6.0.4/lib/net20/Newtonsoft.Json.xml
+++ b/packages/Newtonsoft.Json.6.0.4/lib/net20/Newtonsoft.Json.xml
@@ -3046,10 +3046,10 @@
             <remarks>
             This attribute allows us to define extension methods without 
             requiring .NET Framework 3.5. For more information, see the section,
-            <a href="http://msdn.microsoft.com/en-us/magazine/cc163317.aspx#S7">Extension Methods in .NET Framework 2.0 Apps</a>,
-            of <a href="http://msdn.microsoft.com/en-us/magazine/cc163317.aspx">Basic Instincts: Extension Methods</a>
+            <a href="http://msdn.microsoft.com/magazine/cc163317.aspx#S7">Extension Methods in .NET Framework 2.0 Apps</a>,
+            of <a href="http://msdn.microsoft.com/magazine/cc163317.aspx">Basic Instincts: Extension Methods</a>
             column in <a href="http://msdn.microsoft.com/msdnmag/">MSDN Magazine</a>, 
-            issue <a href="http://msdn.microsoft.com/en-us/magazine/cc135410.aspx">Nov 2007</a>.
+            issue <a href="http://msdn.microsoft.com/magazine/cc135410.aspx">Nov 2007</a>.
             </remarks>
         </member>
         <member name="T:Newtonsoft.Json.Linq.JPropertyDescriptor">

--- a/packages/jQuery.1.10.2/Content/Scripts/jquery-1.10.2.js
+++ b/packages/jQuery.1.10.2/Content/Scripts/jquery-1.10.2.js
@@ -2941,7 +2941,7 @@ support.sortDetached = assert(function( div1 ) {
 
 // Support: IE<8
 // Prevent attribute/property "interpolation"
-// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+// http://msdn.microsoft.com/library/ms536429%28VS.85%29.aspx
 if ( !assert(function( div ) {
 	div.innerHTML = "<a href='#'></a>";
 	return div.firstChild.getAttribute("href") === "#" ;
@@ -4634,7 +4634,7 @@ if ( !getSetAttribute ) {
 
 
 // Some attributes require a special call on IE
-// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+// http://msdn.microsoft.com/library/ms536429%28VS.85%29.aspx
 if ( !jQuery.support.hrefNormalized ) {
 	// href/src property should get the full normalized URL (#10299/#12915)
 	jQuery.each([ "href", "src" ], function( i, name ) {
@@ -6810,7 +6810,7 @@ var iframe, getStyles, curCSS,
 	ropacity = /opacity\s*=\s*([^)]*)/,
 	rposition = /^(top|right|bottom|left)$/,
 	// swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
-	// see here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+	// see here for display values: https://developer.mozilla.org/docs/CSS/display
 	rdisplayswap = /^(none|table(?!-c[ea]).+)/,
 	rmargin = /^margin/,
 	rnumsplit = new RegExp( "^(" + core_pnum + ")(.*)$", "i" ),


### PR DESCRIPTION
URLs update/cleanup as part of a sweep of MicrosoftEdge org repo's:
* Changed docs.microsoft.com to learn.microsoft.com.
* Removed /en-us/ locale after testing each site without it.

No other changes.